### PR TITLE
修复部分 API 因 JSDoc 注释错误导致 TS 类型检查不通过的问题

### DIFF
--- a/core/Query.js
+++ b/core/Query.js
@@ -58,7 +58,7 @@ class Query {
    *
    * @param {string} key - 用于查询判断的字段
    * @param {string} operator - 判断操作符
-   * @param {string} value - 用于判断的值
+   * @param {any} value - 用于判断的值
    * @returns {this} Query 实例
    */
   compare(key, operator, value) {

--- a/sdk-file/src/wechat/getWXACode.js
+++ b/sdk-file/src/wechat/getWXACode.js
@@ -76,7 +76,7 @@ const makeRealParams = (type, params, cdn, categoryName) => {
  * @param {object} params 参数
  * @param {boolean} [cdn] 是否上传二维码到文件存储并返回图片链接，默认为 false
  * @param {string} [categoryName] 指定上传文件分类名，cdn 为 true 时有效，不指定该参数或分类名不存在，则默认上传到根目录
- * @return {Promise<BaaS.Response<any>>}
+ * @return {Promise<BaaS.GetWXACodeResponse>}
  */
 const getWXACode = (type, params, cdn, categoryName) => {
   let realParams = makeRealParams(type, params, cdn, categoryName)

--- a/sdk-file/src/wechat/types.js
+++ b/sdk-file/src/wechat/types.js
@@ -86,3 +86,11 @@
  * @param {function} [getUserInfo] 获取用户信息 wx.getUserInfo
  * @param {function} [requestPayment] 请求支付 wx.requestPayment
  */
+
+/**
+ * @typedef GetWXACodeResponse
+ * @memberof BaaS
+ * @property {string} image 二维码的 base64 编码
+ * @property {string} [download_url] 请求参数 cdn=true 时返回，二维码的下载链接
+ * @property {object} [uploaded_file] 请求参数 cdn=true 时返回，图片文件对象。SDK >= 3.7.0 返回该参数
+ */

--- a/types/test/core/Query.test.ts
+++ b/types/test/core/Query.test.ts
@@ -49,18 +49,28 @@ expectType<WebBaaS.Query>(wx.BaaS.Query.or(queryWeb, queryWeb))
  */
 // wechat
 expectType<WechatBaaS.Query>(queryWechat.compare('key', '=', 'test'))
+expectType<WechatBaaS.Query>(queryWechat.compare('key', '=', true))
+expectType<WechatBaaS.Query>(queryWechat.compare('key', '=', 1))
 
 // qq
 expectType<QqBaaS.Query>(queryQq.compare('key', '=', 'test'))
+expectType<QqBaaS.Query>(queryQq.compare('key', '=', true))
+expectType<QqBaaS.Query>(queryQq.compare('key', '=', 1))
 
 // alipay
 expectType<AlipayBaaS.Query>(queryAlipay.compare('key', '=', 'test'))
+expectType<AlipayBaaS.Query>(queryAlipay.compare('key', '=', true))
+expectType<AlipayBaaS.Query>(queryAlipay.compare('key', '=', 1))
 
 // baidu
 expectType<BaiduBaaS.Query>(queryBaidu.compare('key', '=', 'test'))
+expectType<BaiduBaaS.Query>(queryBaidu.compare('key', '=', true))
+expectType<BaiduBaaS.Query>(queryBaidu.compare('key', '=', 1))
 
 // web
 expectType<WebBaaS.Query>(queryWeb.compare('key', '=', 'test'))
+expectType<WebBaaS.Query>(queryWeb.compare('key', '=', true))
+expectType<WebBaaS.Query>(queryWeb.compare('key', '=', 1))
 
 
 

--- a/types/test/web.test.ts
+++ b/types/test/web.test.ts
@@ -41,9 +41,9 @@ expectType<Promise<WechatBaaS.Response<any>>>(wx.BaaS.getCensorResult(1))
 /**
  * getWXACode
  */
-expectType<Promise<WechatBaaS.Response<any>>>(wx.BaaS.getWXACode('type', {}))
-expectType<Promise<WechatBaaS.Response<any>>>(wx.BaaS.getWXACode('type', {}, true))
-expectType<Promise<WechatBaaS.Response<any>>>(wx.BaaS.getWXACode('type', {}, true, 'category'))
+expectType<Promise<WechatBaaS.GetWXACodeResponse>>(wx.BaaS.getWXACode('type', {}))
+expectType<Promise<WechatBaaS.GetWXACodeResponse>>(wx.BaaS.getWXACode('type', {}, true))
+expectType<Promise<WechatBaaS.GetWXACodeResponse>>(wx.BaaS.getWXACode('type', {}, true, 'category'))
 
 /**
  * pay

--- a/types/test/wechat.test.ts
+++ b/types/test/wechat.test.ts
@@ -42,9 +42,9 @@ expectType<Promise<WechatBaaS.Response<any>>>(wx.BaaS.getCensorResult(1))
 /**
  * getWXACode
  */
-expectType<Promise<WechatBaaS.Response<any>>>(wx.BaaS.getWXACode('type', {}))
-expectType<Promise<WechatBaaS.Response<any>>>(wx.BaaS.getWXACode('type', {}, true))
-expectType<Promise<WechatBaaS.Response<any>>>(wx.BaaS.getWXACode('type', {}, true, 'category'))
+expectType<Promise<WechatBaaS.GetWXACodeResponse>>(wx.BaaS.getWXACode('type', {}))
+expectType<Promise<WechatBaaS.GetWXACodeResponse>>(wx.BaaS.getWXACode('type', {}, true))
+expectType<Promise<WechatBaaS.GetWXACodeResponse>>(wx.BaaS.getWXACode('type', {}, true, 'category'))
 
 /**
  * pay


### PR DESCRIPTION
项目中引入 `minapp-sdk-typings` 依赖做 TS 类型检查，发现 `wx.BaaS.Query#compare` 和 `wx.BaaS.getWXACode` 方法的 JSDoc 注释有点问题。

若此 PR 没问题，麻烦更新下 NPM 包，谢谢。